### PR TITLE
엔티티 생성 및 연관관계 설정

### DIFF
--- a/src/main/java/com/emodi/emodi/EmodiApplication.java
+++ b/src/main/java/com/emodi/emodi/EmodiApplication.java
@@ -2,8 +2,10 @@ package com.emodi.emodi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class EmodiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/emodi/emodi/entity/Diary.java
+++ b/src/main/java/com/emodi/emodi/entity/Diary.java
@@ -1,0 +1,38 @@
+package com.emodi.emodi.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class Diary {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String title;
+
+	private String content;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "author_id")
+	private User author;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "sentiment_id")
+	private Sentiment sentiment;
+}

--- a/src/main/java/com/emodi/emodi/entity/Sentiment.java
+++ b/src/main/java/com/emodi/emodi/entity/Sentiment.java
@@ -1,0 +1,24 @@
+package com.emodi.emodi.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class Sentiment {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String mood;
+}

--- a/src/main/java/com/emodi/emodi/entity/User.java
+++ b/src/main/java/com/emodi/emodi/entity/User.java
@@ -1,0 +1,28 @@
+package com.emodi.emodi.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "`user`")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class User {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String username;
+
+	private String password;
+}

--- a/src/main/java/com/emodi/emodi/entity/common/BaseTimeEntity.java
+++ b/src/main/java/com/emodi/emodi/entity/common/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package com.emodi.emodi.entity.common;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+@EntityListeners((AuditingEntityListener.class))
+public abstract class BaseTimeEntity {
+	@CreatedDate
+	@Column(updatable = false, nullable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(updatable = true, nullable = false)
+	private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
# 설명
User, Sentiment, Diary 엔티티를 생성하고 연관관계를 설정하였습니다. 
Diary 엔티티는 User 및 Sentiment 엔티티와 단방향 Many-to-One 관계를 가집니다.

# 변경 사항
- `User` 엔티티 생성
  - `id`, `username`, `password` 필드 추가
- `Sentiment` 엔티티 생성
  - `id`, `mood` 필드 추가
- `Diary` 엔티티 생성
  - `id`, `title`, `content` 필드 추가
  - `author` 필드 (User와 Many-to-One 관계)
  - `sentiment` 필드 (Sentiment와 Many-to-One 관계)

# 참고 사항
- 단방향 연관관계를 설정하였으며, 양방향 관계는 설정하지 않았습니다.
- `FetchType.LAZY`로 설정하여 성능 최적화를 고려하였습니다.