### PR TITLE
일기 작성 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    // .env
+    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/emodi/emodi/EmodiApplication.java
+++ b/src/main/java/com/emodi/emodi/EmodiApplication.java
@@ -2,10 +2,12 @@ package com.emodi.emodi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@ConfigurationPropertiesScan
 public class EmodiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/emodi/emodi/config/ClientConfig.java
+++ b/src/main/java/com/emodi/emodi/config/ClientConfig.java
@@ -1,0 +1,13 @@
+package com.emodi.emodi.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class ClientConfig {
+	@Bean
+	public RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
+}

--- a/src/main/java/com/emodi/emodi/config/SentimentProperties.java
+++ b/src/main/java/com/emodi/emodi/config/SentimentProperties.java
@@ -1,0 +1,15 @@
+package com.emodi.emodi.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@ConfigurationProperties(prefix = "app")
+@Getter
+@Setter
+public class SentimentProperties {
+	private String sentimentKey;
+	private String sentimentSecret;
+	private String sentimentUrl;
+}

--- a/src/main/java/com/emodi/emodi/controller/DiaryController.java
+++ b/src/main/java/com/emodi/emodi/controller/DiaryController.java
@@ -1,0 +1,35 @@
+package com.emodi.emodi.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.emodi.emodi.jwt.JwtProvider;
+import com.emodi.emodi.service.DiaryService;
+import com.emodi.emodi.service.dto.request.WriteDiaryRequest;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class DiaryController {
+	private final DiaryService diaryService;
+	private final JwtProvider jwtProvider;
+
+	@PostMapping("/diaries")
+	public ResponseEntity<String> writeDiary(
+		@CookieValue("jwt") String token,
+		@RequestBody WriteDiaryRequest request
+	) {
+		Long userId = jwtProvider.verifyToken(token);
+
+		diaryService.writeDiary(userId, request);
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body("일기 작성이 완료되었습니다.");
+	}
+}

--- a/src/main/java/com/emodi/emodi/entity/Diary.java
+++ b/src/main/java/com/emodi/emodi/entity/Diary.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -37,7 +38,7 @@ public class Diary extends BaseTimeEntity {
 	@JoinColumn(name = "author_id")
 	private User author;
 
-	@ManyToOne(fetch = FetchType.LAZY)
+	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "sentiment_id")
 	private Sentiment sentiment;
 }

--- a/src/main/java/com/emodi/emodi/entity/Sentiment.java
+++ b/src/main/java/com/emodi/emodi/entity/Sentiment.java
@@ -23,4 +23,10 @@ public class Sentiment extends BaseTimeEntity {
 	private Long id;
 
 	private String mood;
+
+	private double neutral;
+
+	private double positive;
+
+	private double negative;
 }

--- a/src/main/java/com/emodi/emodi/repository/DiaryRepository.java
+++ b/src/main/java/com/emodi/emodi/repository/DiaryRepository.java
@@ -1,0 +1,9 @@
+package com.emodi.emodi.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.emodi.emodi.entity.Diary;
+
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+}

--- a/src/main/java/com/emodi/emodi/repository/SentimentRepository.java
+++ b/src/main/java/com/emodi/emodi/repository/SentimentRepository.java
@@ -1,0 +1,8 @@
+package com.emodi.emodi.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.emodi.emodi.entity.Sentiment;
+
+public interface SentimentRepository extends JpaRepository<Sentiment, Long> {
+}

--- a/src/main/java/com/emodi/emodi/service/DiaryService.java
+++ b/src/main/java/com/emodi/emodi/service/DiaryService.java
@@ -1,0 +1,33 @@
+package com.emodi.emodi.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.emodi.emodi.entity.Diary;
+import com.emodi.emodi.entity.Sentiment;
+import com.emodi.emodi.entity.User;
+import com.emodi.emodi.repository.DiaryRepository;
+import com.emodi.emodi.repository.UserRepository;
+import com.emodi.emodi.service.dto.request.WriteDiaryRequest;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DiaryService {
+	private final UserRepository userRepository;
+	private final DiaryRepository diaryRepository;
+	private final SentimentService sentimentService;
+
+	public Diary writeDiary(Long userId, WriteDiaryRequest request) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+		Sentiment sentiment = sentimentService.analyze(request);
+
+		Diary diary = request.toDiary(user, sentiment);
+
+		return diaryRepository.save(diary);
+	}
+}

--- a/src/main/java/com/emodi/emodi/service/SentimentAnalyzer.java
+++ b/src/main/java/com/emodi/emodi/service/SentimentAnalyzer.java
@@ -1,0 +1,42 @@
+package com.emodi.emodi.service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import com.emodi.emodi.config.SentimentProperties;
+import com.emodi.emodi.service.dto.response.SentimentResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SentimentAnalyzer {
+	private final SentimentProperties sentimentProperties;
+	private final RestTemplate restTemplate;
+
+	public SentimentResponse analyze(String content) {
+		HttpHeaders httpHeaders = new HttpHeaders();
+		httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+		httpHeaders.set("X-NCP-APIGW-API-KEY-ID", sentimentProperties.getSentimentKey());
+		httpHeaders.set("X-NCP-APIGW-API-KEY", sentimentProperties.getSentimentSecret());
+
+		Map<String, String> requestBody = new HashMap<>();
+		requestBody.put("content", content);
+
+		HttpEntity<Map<String, String>> httpRequest = new HttpEntity<>(requestBody, httpHeaders);
+
+		ResponseEntity<SentimentResponse> httpResponse = restTemplate.postForEntity(
+			sentimentProperties.getSentimentUrl(),
+			httpRequest,
+			SentimentResponse.class);
+
+		return httpResponse.getBody();
+	}
+}

--- a/src/main/java/com/emodi/emodi/service/SentimentService.java
+++ b/src/main/java/com/emodi/emodi/service/SentimentService.java
@@ -1,0 +1,34 @@
+package com.emodi.emodi.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.emodi.emodi.entity.Sentiment;
+import com.emodi.emodi.repository.SentimentRepository;
+import com.emodi.emodi.service.dto.request.WriteDiaryRequest;
+import com.emodi.emodi.service.dto.response.SentimentResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SentimentService {
+	private final SentimentAnalyzer sentimentAnalyzer;
+	private final SentimentRepository sentimentRepository;
+
+	public Sentiment analyze(WriteDiaryRequest request) {
+		SentimentResponse sentimentResponse = sentimentAnalyzer.analyze(request.content());
+		SentimentResponse.Document document = sentimentResponse.getDocument();
+		SentimentResponse.Confidence confidence = document.getConfidence();
+
+		Sentiment sentiment = Sentiment.builder()
+			.mood(document.getSentiment())
+			.neutral(confidence.getNeutral())
+			.positive(confidence.getPositive())
+			.negative(confidence.getNegative())
+			.build();
+
+		return sentimentRepository.save(sentiment);
+	}
+}

--- a/src/main/java/com/emodi/emodi/service/dto/request/WriteDiaryRequest.java
+++ b/src/main/java/com/emodi/emodi/service/dto/request/WriteDiaryRequest.java
@@ -1,0 +1,23 @@
+package com.emodi.emodi.service.dto.request;
+
+import java.time.LocalDate;
+
+import com.emodi.emodi.entity.Diary;
+import com.emodi.emodi.entity.Sentiment;
+import com.emodi.emodi.entity.User;
+
+public record WriteDiaryRequest(
+	String date,
+	String title,
+	String content
+) {
+	public Diary toDiary(User user, Sentiment sentiment) {
+		return Diary.builder()
+			.date(LocalDate.parse(date))
+			.title(title)
+			.content(content)
+			.author(user)
+			.sentiment(sentiment)
+			.build();
+	}
+}

--- a/src/main/java/com/emodi/emodi/service/dto/response/SentimentResponse.java
+++ b/src/main/java/com/emodi/emodi/service/dto/response/SentimentResponse.java
@@ -1,0 +1,44 @@
+package com.emodi.emodi.service.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SentimentResponse {
+	@JsonProperty("document")
+	private Document document;
+
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class Document {
+		@JsonProperty("sentiment")
+		private String sentiment;
+
+		@JsonProperty("confidence")
+		private Confidence confidence;
+	}
+
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class Confidence {
+		@JsonProperty("neutral")
+		private double neutral;
+
+		@JsonProperty("positive")
+		private double positive;
+
+		@JsonProperty("negative")
+		private double negative;
+	}
+}

--- a/src/test/java/com/emodi/emodi/service/DiaryServiceTest.java
+++ b/src/test/java/com/emodi/emodi/service/DiaryServiceTest.java
@@ -1,0 +1,45 @@
+package com.emodi.emodi.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.emodi.emodi.entity.Diary;
+import com.emodi.emodi.entity.User;
+import com.emodi.emodi.repository.UserRepository;
+import com.emodi.emodi.service.dto.request.WriteDiaryRequest;
+
+@SpringBootTest
+class DiaryServiceTest {
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private DiaryService diaryService;
+	private User user;
+
+	@BeforeEach
+	void setUp() {
+		user = User.builder()
+			.id(1L)
+			.build();
+
+		userRepository.save(user);
+	}
+
+	@Test
+	public void 다이어리_생성_성공() {
+		// given
+		WriteDiaryRequest request = new WriteDiaryRequest("2024-06-17", "햅삐햅삐", "재미있다");
+
+		// when
+		Diary diary = diaryService.writeDiary(1L, request);
+
+		// then
+		assertThat(diary.getId()).isEqualTo(1L);
+		assertThat(diary.getAuthor().getId()).isEqualTo(user.getId());
+		assertThat(diary.getSentiment().getMood()).isEqualTo("positive");
+	}
+}


### PR DESCRIPTION
# 설명
감정 분석 api를 활용하여 일기 작성 로직을 구현했습니다.

# 변경 사항
Diary와 Sentiment 연관관계를 OneToOne으로 변경했습니다.
feature/sentiment-analysis 브랜치의 기존 코드를 기반으로 감정 분석 api 로직을 리팩토링했습니다.

# 참고 사항
build.gradle 파일에 .env 파일을 사용하기 위한 의존성을 추가했습니다. 
일기 작성 로직에 감정 분석 API 호출을 추가하여, 일기 저장 시 감정 분석 결과도 함께 저장되도록 수정했습니다.
감정은 neutral, positive, negative 세 가지로 나타나며, 각 감정의 수치 분포를 확인할 수 있습니다.
DiaryService 테스트 코드도 성공적으로 실행되었습니다.