### PR TITLE
refactor: 일기 작성 후 관련 데이터 응답 추가

### DIFF
--- a/src/main/java/com/emodi/emodi/controller/DiaryController.java
+++ b/src/main/java/com/emodi/emodi/controller/DiaryController.java
@@ -8,9 +8,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import com.emodi.emodi.entity.Diary;
 import com.emodi.emodi.jwt.JwtProvider;
 import com.emodi.emodi.service.DiaryService;
 import com.emodi.emodi.service.dto.request.WriteDiaryRequest;
+import com.emodi.emodi.service.dto.response.WriteDiaryResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,14 +24,20 @@ public class DiaryController {
 	private final JwtProvider jwtProvider;
 
 	@PostMapping("/diaries")
-	public ResponseEntity<String> writeDiary(
+	public ResponseEntity<WriteDiaryResponse> writeDiary(
 		@CookieValue("jwt") String token,
 		@RequestBody WriteDiaryRequest request
 	) {
 		Long userId = jwtProvider.verifyToken(token);
 
-		diaryService.writeDiary(userId, request);
+		Diary diary = diaryService.writeDiary(userId, request);
+
+		WriteDiaryResponse writeDiaryResponse = WriteDiaryResponse.toWriteDiaryResponse(
+			"일기 작성이 완료되었습니다.",
+			diary
+		);
+
 		return ResponseEntity.status(HttpStatus.CREATED)
-			.body("일기 작성이 완료되었습니다.");
+			.body(writeDiaryResponse);
 	}
 }

--- a/src/main/java/com/emodi/emodi/entity/common/BaseTimeEntity.java
+++ b/src/main/java/com/emodi/emodi/entity/common/BaseTimeEntity.java
@@ -9,8 +9,10 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 
 @MappedSuperclass
+@Getter
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {
 	@CreatedDate

--- a/src/main/java/com/emodi/emodi/service/DiaryService.java
+++ b/src/main/java/com/emodi/emodi/service/DiaryService.java
@@ -29,5 +29,6 @@ public class DiaryService {
 		Diary diary = request.toDiary(user, sentiment);
 
 		return diaryRepository.save(diary);
+
 	}
 }

--- a/src/main/java/com/emodi/emodi/service/dto/response/DairyDto.java
+++ b/src/main/java/com/emodi/emodi/service/dto/response/DairyDto.java
@@ -1,0 +1,25 @@
+package com.emodi.emodi.service.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.emodi.emodi.entity.Diary;
+
+public record DairyDto(
+	Long diaryId,
+	Long authorId,
+	String title,
+	String content,
+	LocalDateTime createdAt,
+	LocalDateTime updatedAt
+) {
+	public static DairyDto toDiaryDto(Diary diary) {
+		return new DairyDto(
+			diary.getId(),
+			diary.getAuthor().getId(),
+			diary.getTitle(),
+			diary.getContent(),
+			diary.getCreatedAt(),
+			diary.getUpdatedAt()
+		);
+	}
+}

--- a/src/main/java/com/emodi/emodi/service/dto/response/SentimentDto.java
+++ b/src/main/java/com/emodi/emodi/service/dto/response/SentimentDto.java
@@ -1,0 +1,19 @@
+package com.emodi.emodi.service.dto.response;
+
+import com.emodi.emodi.entity.Sentiment;
+
+public record SentimentDto(
+	String mood,
+	double neutral,
+	double positive,
+	double negative
+) {
+	public static SentimentDto toSentimentDto(Sentiment sentiment) {
+		return new SentimentDto(
+			sentiment.getMood(),
+			sentiment.getNeutral(),
+			sentiment.getPositive(),
+			sentiment.getNegative()
+		);
+	}
+}

--- a/src/main/java/com/emodi/emodi/service/dto/response/WriteDiaryResponse.java
+++ b/src/main/java/com/emodi/emodi/service/dto/response/WriteDiaryResponse.java
@@ -1,0 +1,17 @@
+package com.emodi.emodi.service.dto.response;
+
+import com.emodi.emodi.entity.Diary;
+
+public record WriteDiaryResponse(
+	String message,
+	DairyDto dairyDto,
+	SentimentDto sentimentDto
+) {
+	public static WriteDiaryResponse toWriteDiaryResponse(String message, Diary dairy) {
+		return new WriteDiaryResponse(
+			message,
+			DairyDto.toDiaryDto(dairy),
+			SentimentDto.toSentimentDto(dairy.getSentiment())
+		);
+	}
+}


### PR DESCRIPTION
#설명
 일기 작성 후 관련 데이터 응답으로 추가했습니다.

#변경 사항
BaseTimeEntity에 @Getter를 추가하여 생성일자와 수정일자를 가져오도록 했습니다.
프로젝트 일정을 맞추기 위해, 일기 작성 후 다이어리와 감정 데이터를 응답으로 보내도록 수정했습니다.
(다이어리 조회 API에서 오류가 발생할 경우, 해당 응답 데이터를 사용해주세요)

#참고 사항
